### PR TITLE
fixing to pre_lut_num_val_minus1 condition check.

### DIFF
--- a/hevcparser/src/HevcParserImpl.cpp
+++ b/hevcparser/src/HevcParserImpl.cpp
@@ -2178,7 +2178,7 @@ void HevcParserImpl::processColourRemappingInfo(std::shared_ptr<ColourRemappingI
       pSeiPayload -> pre_lut_num_val_minus1[i] = bs.getBits(8);
 
 
-      if(pSeiPayload -> pre_lut_num_val_minus1> 0)
+      if(pSeiPayload -> pre_lut_num_val_minus1[i] > 0)
       {
         pSeiPayload -> pre_lut_coded_value[i].resize(pSeiPayload -> pre_lut_num_val_minus1[i]+1);
         pSeiPayload -> pre_lut_target_value[i].resize(pSeiPayload -> pre_lut_num_val_minus1[i]+1);


### PR DESCRIPTION
error: ordered comparison between pointer and zero ('uint8_t *'(aka 'unsigned char *') and 'int')
      if(pSeiPayload -> pre_lut_num_val_minus1> 0)
---
environment) macOS High Sierra
% cc --version
Apple LLVM version 9.0.0 (clang-900.0.38)
Target: x86_64-apple-darwin17.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin