### PR TITLE
fixing to pre_lut_num_val_minus1 array reference. (utils/hevc_es_browser_gui/SyntaxViewer.cpp)

### DIFF
--- a/utils/hevc_es_browser_gui/SyntaxViewer.cpp
+++ b/utils/hevc_es_browser_gui/SyntaxViewer.cpp
@@ -2502,12 +2502,12 @@ void SyntaxViewer::createColourRemappingInfo(std::shared_ptr<HEVC::ColourRemappi
     {
       ploop -> addChild(new QTreeWidgetItem(QStringList("pre_lut_num_val_minus1[" + QString::number(i) + "] = " + QString::number(pSei -> pre_lut_num_val_minus1[i]))));
 
-      if(pSei -> pre_lut_num_val_minus1> 0)
+      if(pSei -> pre_lut_num_val_minus1[i] > 0)
       {
-        QTreeWidgetItem *pitemIfSecond = new QTreeWidgetItem(QStringList("if( pre_lut_num_val_minus1 > 0 )"));
+        QTreeWidgetItem *pitemIfSecond = new QTreeWidgetItem(QStringList("if( pre_lut_num_val_minus1[" + QString::number(i) + "] > 0 )"));
         ploop -> addChild(pitemIfSecond);
 
-        QTreeWidgetItem *ploopSecond = new QTreeWidgetItem(QStringList("for( j = 0; j <= pre_lut_num_val_minus1; j++ )"));
+        QTreeWidgetItem *ploopSecond = new QTreeWidgetItem(QStringList("for( j = 0; j <= pre_lut_num_val_minus1[" + QString::number(i) + "]; j++ )"));
         pitemIfSecond -> addChild(ploopSecond);
   
         for (std::size_t j=0 ; j<=pSei -> pre_lut_num_val_minus1[i]; j++)
@@ -2550,12 +2550,12 @@ void SyntaxViewer::createColourRemappingInfo(std::shared_ptr<HEVC::ColourRemappi
     {
       ploop -> addChild(new QTreeWidgetItem(QStringList("post_lut_num_val_minus1[" + QString::number(i) + "] = " + QString::number(pSei -> post_lut_num_val_minus1[i]))));
 
-      if(pSei -> post_lut_num_val_minus1> 0)
+      if(pSei -> post_lut_num_val_minus1[i] > 0)
       {
-        QTreeWidgetItem *pitemIfSecond = new QTreeWidgetItem(QStringList("if( post_lut_num_val_minus1 > 0 )"));
+        QTreeWidgetItem *pitemIfSecond = new QTreeWidgetItem(QStringList("if( post_lut_num_val_minus1[" + QString::number(i) + "] > 0 )"));
         ploop -> addChild(pitemIfSecond);
 
-        QTreeWidgetItem *ploopSecond = new QTreeWidgetItem(QStringList("for( j = 0; j <= post_lut_num_val_minus1; j++ )"));
+        QTreeWidgetItem *ploopSecond = new QTreeWidgetItem(QStringList("for( j = 0; j <= post_lut_num_val_minus1[" + QString::number(i) + "]; j++ )"));
         pitemIfSecond -> addChild(ploopSecond);
   
         for (std::size_t j=0 ; j<=pSei -> post_lut_num_val_minus1[i]; j++)


### PR DESCRIPTION
error: ordered comparison between pointer and zero
---
environment) macOS Mojave

```
% cc --version
Apple LLVM version 10.0.0 (clang-1000.10.44.4)
Target: x86_64-apple-darwin18.2.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

error log)

```
SyntaxViewer.cpp:2505:40: error: ordered comparison between pointer and zero
      ('uint8_t *' (aka 'unsigned char *') and 'int')
      if(pSei -> pre_lut_num_val_minus1> 0)
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ ~
SyntaxViewer.cpp:2553:41: error: ordered comparison between pointer and zero
      ('uint8_t *' (aka 'unsigned char *') and 'int')
      if(pSei -> post_lut_num_val_minus1> 0)
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ ~
3 warnings and 2 errors generated.
make: *** [../../build/qt/SyntaxViewer.o] Error 1
```