### PR TITLE
bugfix when skipbits

### DIFF
--- a/hevcparser/src/BitstreamReader.cpp
+++ b/hevcparser/src/BitstreamReader.cpp
@@ -27,15 +27,15 @@ std::size_t BitstreamReader::availableInNalU()
     pos++;
   for(; pos<(m_size - 3); pos++)
   {
-    bool naluFinded = m_ptr[pos] == 0 && m_ptr[pos+1] == 0 && m_ptr[pos+2] == 1;
+    bool naluFound = m_ptr[pos] == 0 && m_ptr[pos+1] == 0 && m_ptr[pos+2] == 1;
 
-    if(!naluFinded)
+    if(!naluFound)
     {
       if(m_size - pos >= 4 && m_ptr[pos] == 0 && m_ptr[pos+1] == 0 && m_ptr[pos+2] == 0 && m_ptr[pos+3] == 1)
-        naluFinded = true;
+        naluFound = true;
     }
 
-    if(naluFinded)
+    if(naluFound)
     {
       return (pos - m_posBase - 1) * CHAR_BIT + m_posInBase + 1;
     }

--- a/hevcparser/src/BitstreamReader.cpp
+++ b/hevcparser/src/BitstreamReader.cpp
@@ -106,7 +106,7 @@ void BitstreamReader::skipBits(std::size_t num)
     }
   }
 
-  if(m_posInBase > num % 8)
+  if(m_posInBase >= num % 8)
     m_posInBase -= num % 8;
   else
   {


### PR DESCRIPTION
BitstreamReader.cpp 
``` 
if(m_posInBase > num % 8)
    m_posInBase -= num % 8;
  else
  {
    m_posBase++;
    m_posInBase = m_posInBase - num % 8 + 8;
  }
```
Here `if(m_posInBase > num % 8)` should be `if(m_posInBase >= num % 8)`. Fortunately, this minor bug has not caused any issues so far, because the function is only used in one place, where it skips an integer number of bytes.